### PR TITLE
ENH: Selecting next bundle is now consistent

### DIFF
--- a/bin/dipy_streamlines_viz.py
+++ b/bin/dipy_streamlines_viz.py
@@ -303,7 +303,7 @@ class StreamlinesVizu(object):
 
     def select_next(self):
         # Sort bundle according to their bundle size.
-        indices = np.argsort([len(self.bundles[k].streamlines) for k in self.keys]).tolist()[::-1]
+        indices = np.lexsort((self.keys, [len(self.bundles[k].streamlines) for k in self.keys])).tolist()[::-1]
 
         if self.selected_bundle is None:
             cpt = 0
@@ -316,7 +316,7 @@ class StreamlinesVizu(object):
 
     def select_previous(self):
         # Sort bundle according to their bundle size.
-        indices = np.argsort([len(self.bundles[k].streamlines) for k in self.keys]).tolist()[::-1]
+        indices = np.lexsort((self.keys, [len(self.bundles[k].streamlines) for k in self.keys])).tolist()[::-1]
 
         if self.selected_bundle is None:
             cpt = 0


### PR DESCRIPTION
Use `numpy.lexsort` instead of `numpy.argsort` in order to have multiple sorting fields.
First sort on bundle size, then on bundle name (sorting fields are given in reverse order). See the [numpy documentation](https://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.lexsort.html) for more info.